### PR TITLE
fix(seo): disable taxonomy pages (#12)

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -4,6 +4,8 @@ title = 'Сережа Рис'
 defaultContentLanguage = 'ru'
 enableRobotsTXT = true
 
+[taxonomies]
+
 [permalinks]
   blog = '/blog/:contentbasename'
 


### PR DESCRIPTION
## Summary
- Disable Hugo taxonomy pages (/tags/*) to free crawl budget
- 108 tag pages were consuming 40-60% of crawl budget on a young domain
- Tags in frontmatter remain for Hugo Related Content

Closes #12

## Test plan
- [x] `hugo build` succeeds
- [x] No /tags/ directory in public/
- [x] sitemap.xml clean from tag URLs