### PR TITLE
fix(seo): sync trailing slash Hugo ↔ Vercel (#13)

### DIFF
--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -2,14 +2,14 @@
 <meta name="description" content="{{ .Description | default .Site.Params.description }}">
 <meta name="author" content="{{ .Site.Params.author }}">
 {{ with .Keywords }}<meta name="keywords" content="{{ delimit . ", " }}">{{ end }}
-<link rel="canonical" href="{{ .Permalink | strings.TrimSuffix "/" }}">
+<link rel="canonical" href="{{ .Permalink }}">
 
 <!-- Open Graph -->
 <meta property="og:title" content="{{ .Title }}">
 <meta property="og:description" content="{{ .Description | default .Site.Params.description }}">
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
 <meta property="og:locale" content="ru_RU">
-<meta property="og:url" content="{{ .Permalink | strings.TrimSuffix "/" }}">
+<meta property="og:url" content="{{ .Permalink }}">
 <meta property="og:site_name" content="{{ .Site.Title }}">
 {{ with .Params.image }}
 <meta property="og:image" content="{{ . | absURL }}">
@@ -54,7 +54,7 @@
   "dateModified": "{{ .Lastmod.Format "2006-01-02" }}",
   "mainEntityOfPage": {
     "@type": "WebPage",
-    "@id": "{{ .Permalink | strings.TrimSuffix "/" }}"
+    "@id": "{{ .Permalink }}"
   },
   "wordCount": {{ .WordCount }},
   {{ with .Params.section }}"articleSection": "{{ . }}",{{ end }}
@@ -92,7 +92,7 @@
   "@type": "Blog",
   "name": "{{ .Title }}",
   "description": "{{ .Site.Params.description }}",
-  "url": "{{ .Permalink | strings.TrimSuffix "/" }}",
+  "url": "{{ .Permalink }}",
   "author": {
     "@type": "Person",
     "name": "{{ .Site.Params.author }}",

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,5 +1,5 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {{ range .Data.Pages }}{{ $loc := .Permalink | strings.TrimSuffix "/" }}{{ if and $loc (eq .Section "blog") }}
+  {{ range .Data.Pages }}{{ $loc := .Permalink }}{{ if and $loc (eq .Section "blog") }}
   <url>
     <loc>{{ $loc }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}

--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,5 @@
   "framework": "hugo",
   "outputDirectory": "public",
   "cleanUrls": true,
-  "trailingSlash": false
+  "trailingSlash": true
 }


### PR DESCRIPTION
## Summary
- Set `trailingSlash: true` in vercel.json to match Hugo URL generation
- Remove `TrimSuffix "/"` from canonical, og:url, and JSON-LD in seo.html
- Eliminates 308 redirect chains (6 pages in GSC as "Page with redirect")

Closes #13

## Test plan
- [x] `hugo build` succeeds
- [x] Canonical URLs end with `/`
- [x] og:url and JSON-LD @id consistent with canonical