### PR TITLE
feat(seo): add related posts to blog posts (#16)

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -48,3 +48,13 @@ enableRobotsTXT = true
 [sitemap]
   changefreq = ''
   priority = -1
+
+[related]
+  threshold = 80
+  includeNewer = true
+  [[related.indices]]
+    name = "tags"
+    weight = 100
+  [[related.indices]]
+    name = "date"
+    weight = 10

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -69,6 +69,11 @@
     .sources ul { list-style: none; padding: 0; }
     .sources li { margin-bottom: 4px; }
 
+    .related-posts { margin-top: 30px; padding-top: 20px; border-top: 1px solid #000; }
+    .related-posts h3 { font-size: 14px; margin-bottom: 8px; }
+    .related-posts ul { list-style: none; padding: 0; }
+    .related-posts li { margin-bottom: 4px; }
+
     .author-link { font-size: 13px; }
 
     .subscribe-inline { font-size: 14px; margin: 30px 0 20px; }

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -21,6 +21,18 @@
   </div>
   {{ end }}
 
+  {{ $related := .Site.RegularPages.Related . | first 3 }}
+  {{ with $related }}
+  <div class="related-posts">
+    <h3>Читайте также</h3>
+    <ul>
+      {{ range . }}
+      <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+      {{ end }}
+    </ul>
+  </div>
+  {{ end }}
+
   <p class="author-link"><a href="/about/">Об авторе</a></p>
 
   <p class="subscribe-inline">Подписаться на обновления — <a href="https://t.me/sereja_tech" target="_blank">@sereja_tech</a></p>


### PR DESCRIPTION
## Summary
- Add Hugo Related Content config (tags weight: 100, date weight: 10)
- Show 3 related posts at bottom of each blog post
- Eliminates orphan pages (77% of posts had zero internal links)

Closes #16

## Test plan
- [x] `hugo build` succeeds
- [x] Related posts appear in generated HTML
- [x] Links are relevant (based on tags)
- [x] Style consistent with blog design