### PR TITLE
fix(seo): restore AI crawler rules in robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,3 +1,23 @@
 User-agent: *
+Allow: /
+
+# AI Crawlers - explicitly allowed for GEO
+User-agent: GPTBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
 
 Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
## Summary

- `layouts/robots.txt` was overriding `static/robots.txt` at build time with a minimal template (no AI crawler rules)
- Restored all `Allow` directives and AI crawler entries to the Hugo template
- Sitemap URL remains dynamic via `absURL` instead of hardcoded

## Test plan

- [x] `hugo build` completes without errors
- [x] `public/robots.txt` contains all AI crawler rules
- [x] Sitemap resolves to `https://sereja.tech/sitemap.xml`