### PR TITLE
feat(home): data-driven YouTube section (featured + 3 recent)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,18 @@
 | Path | Purpose |
 |------|---------|
 | `content/blog/*.md` | Статьи |
+| `data/videos.yml` | 4 последних YouTube-видео для блока на главной (featured + 3) |
 | `layouts/` | Hugo шаблоны |
 | `static/` | JS, images |
 | `scripts/og-preview/` | OG-превью генератор (HTML → Playwright → PNG 1200×630) |
 | `hugo.toml` | Конфиг Hugo |
 | `index.html` | Legacy главная (вне Hugo) |
+
+## YouTube Block
+
+Секция «YouTube» на главной (`layouts/index.html`) — data-driven из `data/videos.yml`. Первая запись = featured iframe + подпись «Последнее видео: {label}». Следующие 3 — список с thumbnail 80×45 (грузятся с `i.ytimg.com/vi/{id}/mqdefault.jpg`).
+
+Обновление = часть lifecycle стрима, **живёт не здесь**. Владелец процесса — `live-sereja-tech/AGENTS.md` § 9.1 «YouTube Broadcast Lifecycle», шаг «D+1 refresh». IDs/titles canonical в `~/Documents/GitHub/stats-youtube/videos.json`.
 
 ## Blog Workflow
 

--- a/data/videos.yml
+++ b/data/videos.yml
@@ -1,0 +1,16 @@
+# Последние YouTube-видео/стримы. Первый = featured (iframe на главной).
+# Как обновить: после публикации нового — новое сверху, старое с конца выкинуть.
+videos:
+  - id: 05xs_kyacxI
+    title: "GPT Image 2: разбор новой модели OpenAI"
+    label: "GPT Image 2"
+    date: 2026-04-21
+  - id: yX9-bOj1Mu0
+    title: "Claude Design: обзор нового AI для дизайна, прототипов и презентаций"
+    date: 2026-04-17
+  - id: tqDBIhMjo8w
+    title: "Claude Opus 4.7, обзор, вайбкодинг тесты, сравнение с GPT 5.4"
+    date: 2026-04-16
+  - id: O4KwzNZuaB8
+    title: "Paperclip: как собрать компанию из AI-агентов на базе Claude Code"
+    date: 2026-03-27

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -43,6 +43,17 @@
     .youtube-preview { margin: 20px 0; }
     .youtube-preview iframe { width: 100%; aspect-ratio: 16/9; border: none; }
 
+    .video-list { list-style: none; padding: 0; margin: 12px 0 20px; }
+    .video-list li { margin-bottom: 10px; }
+    .video-item { display: flex; gap: 12px; align-items: flex-start; text-decoration: none; color: inherit; }
+    .video-item:visited { color: inherit; }
+    .video-item img { flex-shrink: 0; display: block; border: 1px solid #000; }
+    .video-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .video-title { color: #0000EE; text-decoration: underline; }
+    .video-item:visited .video-title { color: #551A8B; }
+    .video-item:hover .video-title { text-decoration: none; }
+    .video-meta .date { margin-right: 0; }
+
     img { max-width: 100%; height: auto; display: block; }
     figure { margin: 24px 0; max-width: 100%; }
     figcaption { font-size: 13px; color: #666; margin-top: 6px; }
@@ -121,6 +132,9 @@
       .tag { border-color: #4a4a4a; color: #d1d5db; }
       .tag:visited { color: #d1d5db; }
       .tag:hover { background: #4a4a4a; color: #fff; }
+      .video-item img { border-color: #3a3a3a; }
+      .video-title { color: #7ab0ff; }
+      .video-item:visited .video-title { color: #c4a6f5; }
     }
   </style>
 </head>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,15 +8,31 @@
 </div>
 
 <h2>YouTube</h2>
+{{ with index .Site.Data.videos.videos 0 }}
 <div class="youtube-preview">
   <iframe
-    src="https://www.youtube-nocookie.com/embed/AHIaQKQqfRM"
-    title="Стрим про ClawdBot"
+    src="https://www.youtube-nocookie.com/embed/{{ .id }}"
+    title="{{ .title }}"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowfullscreen>
   </iframe>
 </div>
-<p><small>Последний стрим: ClawdBot · <a href="https://www.youtube.com/@serejaris?utm_source=sereja_tech&utm_medium=link&utm_campaign=youtube_section" target="_blank">Все видео</a></small></p>
+<p><small>Последнее видео: {{ .label }} · <a href="https://www.youtube.com/@serejaris?utm_source=sereja_tech&utm_medium=link&utm_campaign=youtube_section" target="_blank">Все видео</a></small></p>
+{{ end }}
+
+<ul class="video-list">
+  {{ range after 1 .Site.Data.videos.videos }}
+  <li>
+    <a href="https://www.youtube.com/watch?v={{ .id }}" target="_blank" class="video-item">
+      <img src="https://i.ytimg.com/vi/{{ .id }}/mqdefault.jpg" alt="" width="80" height="45" loading="lazy">
+      <span class="video-meta">
+        <span class="video-title">{{ .title }}</span>
+        <span class="date">{{ time.Format "2 Jan 2006" .date }}</span>
+      </span>
+    </a>
+  </li>
+  {{ end }}
+</ul>
 
 <h2>Последнее из блога</h2>
 <ul class="posts">


### PR DESCRIPTION
## Summary

- Pull the homepage YouTube block from `data/videos.yml` instead of a hardcoded iframe.
- First entry = featured iframe + subtitle label.
- Next 3 entries render as a compact list with 80×45 thumbnails pulled from `i.ytimg.com`.
- Document the update workflow in `CLAUDE.md` (pointer to `live-sereja-tech/AGENTS.md` § 9.1 "YouTube Broadcast Lifecycle" → D+1 refresh step).

## Test plan

- [x] `hugo build` — no errors
- [x] `hugo server -D` — visual check on localhost:1313 (light + dark + mobile 375px)
- [x] iframe loads the first video from `data/videos.yml`
- [x] 3 thumbnails load from `i.ytimg.com/vi/{id}/mqdefault.jpg`
- [x] Dark mode: title links readable (`#7ab0ff`), thumbnail border visible
- [x] Mobile: `flex-shrink: 0` keeps thumbnails at 80×45, title wraps