### PR TITLE
Route stack through dedicated Vercel project

### DIFF
--- a/static/tech/index.html
+++ b/static/tech/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!-- Deployment surface: Vercel project tech-sereja-tech, root static/tech. -->
 <html lang="ru">
 <head>
   <meta charset="utf-8">

--- a/static/tech/vercel.json
+++ b/static/tech/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "",
+  "outputDirectory": "."
+}

--- a/vercel.json
+++ b/vercel.json
@@ -8,15 +8,6 @@
   "outputDirectory": "public",
   "cleanUrls": true,
   "trailingSlash": true,
-  "rewrites": [
-    {
-      "source": "/:path*",
-      "has": [
-        { "type": "host", "value": "tech.sereja.tech" }
-      ],
-      "destination": "/tech/:path*"
-    }
-  ],
   "redirects": [
     { "source": "/stack", "destination": "https://tech.sereja.tech/", "permanent": true },
     { "source": "/stack/", "destination": "https://tech.sereja.tech/", "permanent": true },


### PR DESCRIPTION
## Что изменилось

- убран host-based rewrite из основного Hugo-проекта;
- зафиксирован отдельный deployment surface `tech-sereja-tech` с root directory `static/tech`;
- redirect `/stack/ → https://tech.sereja.tech/` сохранён.

## Почему

Корневой `index.html` основного сайта имеет filesystem precedence и перекрывает deployment-level rewrite. Отдельный Git-connected Vercel project даёт поддомену собственный корень и сохраняет `sereja.tech` без изменений.

## Проверки

- `hugo build`
- canonical, sitemap и redirect-source checks
- `git diff --check`
