### PR TITLE
fix(blog): document working Hermes subscription path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 | Дата | Статья |
 |------|--------|
-| 2026-08-04 | [Как перевести Hermes-бота на подписку Anthropic](https://sereja.tech/blog/claude-max-hermes-telegram/) |
+| 2026-08-04 | [Как подключить подписку Anthropic к Hermes](https://sereja.tech/blog/claude-max-hermes-telegram/) |
 | 2026-08-03 | [Почему агент не может выбрать лучший код](https://sereja.tech/blog/best-practices-code/) |
 | 2026-07-18 | [Kimi K3 за 1:47: сильный агент с одной проблемой](https://sereja.tech/blog/kimi-k3-guide/) |
 | 2026-07-18 | [База знаний для агентов: вход, слои и обслуживание](https://sereja.tech/blog/agent-knowledge-base/) |

--- a/content/blog/claude-max-hermes-telegram.md
+++ b/content/blog/claude-max-hermes-telegram.md
@@ -1,144 +1,354 @@
 ---
-title: "Как перевести Hermes-бота на подписку Anthropic"
+title: "Как подключить подписку Anthropic к Hermes"
 date: 2026-08-04
-description: "Рабочая миграция Hermes-бота на Claude Code: подписка Anthropic, тот же Telegram-бот, выбранные скиллы и исправление ответов внутри topics."
+description: "Проверенный путь: Hermes остаётся Telegram runtime, а Opus вызывается через официальный Claude Code CLI и подписку Anthropic без Extra Usage."
 tags: ["hermes", "anthropic", "claude-code", "telegram", "вайбкодинг"]
 image: "/images/blog/claude-max-hermes-telegram-preview.png"
 cta: personal_corp
 cta_code: pc_blog
 ---
 
-Сразу важное: официальный Telegram-плагин Anthropic не подключается внутрь Hermes. Я остановил Telegram gateway Hermes и запустил вместо него Claude Code Telegram Channel на токене того же бота. Имя бота осталось прежним. Модель, подписка и ответы теперь идут через Claude Code.
+Я хотел оставить Hermes самим ботом и подключить к нему Opus через действующую подписку Anthropic. Без API key, отдельного pay-as-you-go и Extra Usage.
 
-Контекст тоже потребовал миграции. Я отдельно перенёс нужные инструкции, один скилл и рабочий репозиторий. История сессий и память Hermes автоматически в Claude Code не переехали. Это замена runtime с выборочным переносом артефактов.
+Связка заработала. Hermes отвечает в Telegram-личке и topics, хранит свои сессии и память, вызывает свои tools.
 
-Схему проверил на живом боте с Opus и подпиской Claude Max. Личка отвечает, проверенный private topic отвечает, сервис переживает рестарт. Extra Usage выключен.
+Каждый основной model turn идёт через официальный Claude Code CLI.
 
-## Что именно меняется
+Мой живой тест выполнен на Claude Max и Opus.
 
-Пользователь продолжает писать тому же Telegram-боту. Под капотом работает другой gateway.
+Архитектура привязана к авторизованной подписочной сессии Claude Code.
 
-| Часть | Что с ней происходит |
+Max здесь пример проверенного тарифа. Сама схема опирается на подписочную сессию Claude Code.
+
+## Как связаны Hermes, provider и Claude CLI
+
+Здесь четыре слоя:
+
+| Слой | Роль |
 |---|---|
-| Telegram-бот | Сохраняются username и токен |
-| Hermes gateway | Останавливается и остаётся готовым для rollback |
-| Claude Code | Становится новым runtime для модели и Telegram |
-| Инструкции и репозитории | Переносятся выборочно в новый workspace |
-| Скиллы | Ставятся отдельно в каталог Claude Code |
-| Память Hermes | Требует отдельного экспорта и адаптации |
-| Оплата модели | Идёт через авторизованную подписку Anthropic |
+| Telegram | Доставляет сообщения существующему боту |
+| Hermes | Ведёт gateway, сессии, память и tool loop |
+| User provider | Переводит запрос Hermes в локальный вызов CLI |
+| Claude Code CLI | Запускает Opus через подписочную сессию Anthropic |
 
-Поэтому фраза "подключить подписку к Hermes" немного обманчива. Рабочая схема переводит существующего Hermes-бота на Claude Code Channel. Сам процесс Hermes больше не обрабатывает сообщения.
+User provider — это community-плагин для штатного каталога Hermes. Он поднимает OpenAI-compatible shim на 127.0.0.1:8765.
 
-## Почему смена провайдера Hermes не подходит
+Hermes обращается к shim как к обычному model provider. Shim запускает официальный claude -p --model opus. Авторизацию и расход лимита контролирует Claude Code.
 
-У Hermes есть собственный Anthropic OAuth. [Документация Hermes](https://hermes-agent.nousresearch.com/docs/integrations/providers) предупреждает, что этот маршрут использует кредиты Extra Usage. Обычный подписочный лимит через него не расходуется.
+~~~text
+Telegram
+   ↕
+Hermes gateway · sessions · memory · tools
+   ↕
+claude-code-cli provider на 127.0.0.1
+   ↕
+официальный claude -p --model opus
+   ↕
+подписка Anthropic
+~~~
 
-Для подписки я использую [Claude Code Channels](https://code.claude.com/docs/en/channels). Claude Code авторизован в аккаунте Anthropic, а официальный Telegram Channel подключён к его живой сессии. В моём тесте тариф был Max, алиас `opus` выбрал `claude-opus-5`. Для другого тарифа сначала стоит проверить доступность Claude Code в аккаунте.
+Официальный Telegram Channel Anthropic в этой схеме не участвует. Это был мой первый обход.
 
-Связка выглядит так:
+В нём Hermes полностью заменялся, поэтому исходная задача оставалась нерешённой.
 
-```text
-Telegram-бот
-     ↕
-официальный Telegram Channel
-     ↕
-Claude Code + подписка Anthropic
-     ↕
-новый workspace
-инструкции · рабочие репозитории
+## Почему здесь работает подписка
 
-каталог Claude Code
-выбранные скиллы
+Native Anthropic OAuth в Hermes использует пул Extra Usage. При выключенном Extra Usage мой живой запрос завершался ошибкой out of extra usage.
 
-Hermes gateway: остановлен, сохранён для rollback
-```
+Provider идёт другим путём. Он запускает официальный Claude Code CLI, уже авторизованный через аккаунт Claude.
 
-Официальный плагин запускается внутри сессии Claude Code. Hermes с ним напрямую не связан. Связь сохраняется на уровне бот-токена, имени бота и тех рабочих артефактов, которые агент перенёс в новый workspace.
+Hermes не хранит Anthropic API key и не вызывает metered API напрямую.
+
+В проверочном запуске Claude сообщил:
+
+- authMethod=claude.ai;
+- apiProvider=firstParty;
+- apiKeySource=none;
+- модель claude-opus-5;
+- окно подписки five_hour разрешено;
+- isUsingOverage=false;
+- overage выключен на уровне организации.
+
+Так я отделяю подписочный маршрут от случайного расхода API или Extra Usage.
+
+## Какой код я использовал
+
+Основа — community provider Ouroborosrex/hermes-claude-code-cli-provider.
+
+Я зафиксировал base commit:
+
+~~~text
+09a3aec0ab7406c6a0731f858f1b4b7a99f0cb77
+~~~
+
+Из PR #12 взял два независимых исправления:
+
+~~~text
+8e5c74c2eb3017fd47f5d1d504625d3c87058b40
+62420fb094a1124292bd4931781b45a8e7ab9633
+~~~
+
+Первое превращает ошибки CLI в HTTP-коды, понятные fallback-механизму Hermes.
+
+Второе проверяет реально обслужившую модель и ловит тихую подмену Opus.
+
+Мой hardening patch добавляет ещё три вещи:
+
+- allowlist окружения дочернего claude;
+- корректный context accounting для Hermes;
+- совместимость с ProviderProfile в Hermes v0.14.
+
+Allowlist важен. Процесс Hermes видит Telegram token и ключи других провайдеров. Передавать всё окружение в Claude CLI нельзя.
+
+Patch оставляет системные переменные и OAuth-настройки Claude Code.
+
+Anthropic API keys, cloud routing, Telegram token и ключи других провайдеров в subprocess не попадают.
+
+Context patch тоже нужен. Внутренний system prompt Claude Code большой.
+
+Если вернуть его usage в Hermes как пользовательский prompt, Hermes может слишком рано сжать контекст.
+
+## Установка
+
+Сначала сохраните container или VM, ~/.hermes, Telegram-конфиг и текущий provider. Зафиксируйте rollback-команды.
+
+У одного Telegram bot token должен быть один poller. Старый gateway останавливайте только перед финальным переключением.
+
+### 1. Установить Claude Code и войти в подписку
+
+Установите официальный Claude Code CLI по документации Anthropic. На целевом сервере выполните:
+
+~~~bash
+claude auth login
+claude auth status --json
+~~~
+
+Ожидаемый статус: вход через claude.ai, first-party provider и ваш subscription type.
+
+Файл credentials держите с mode 0600. Не печатайте OAuth token в логи и не вставляйте его в конфиг Hermes.
+
+### 2. Установить provider
+
+~~~bash
+export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+plugin_dir="$HERMES_HOME/plugins/model-providers/claude-code-cli"
+
+git clone https://github.com/Ouroborosrex/hermes-claude-code-cli-provider "$plugin_dir"
+git -C "$plugin_dir" checkout 09a3aec0ab7406c6a0731f858f1b4b7a99f0cb77
+git -C "$plugin_dir" fetch origin pull/12/head:pr-12
+git -C "$plugin_dir" cherry-pick 8e5c74c2eb3017fd47f5d1d504625d3c87058b40
+git -C "$plugin_dir" cherry-pick 62420fb094a1124292bd4931781b45a8e7ab9633
+~~~
+
+Скачайте мой versioned patch и примените его:
+
+~~~bash
+curl -fsSLo /tmp/hermes-provider-hardening.patch \
+  https://sereja.tech/downloads/hermes-claude-code-cli-provider-hardening.patch
+
+echo "7f2389abd04462df678da2e52b92cf1199a9298cabc6edad3a9bff456d3d242b  /tmp/hermes-provider-hardening.patch" \
+  | sha256sum -c -
+git -C "$plugin_dir" apply --check /tmp/hermes-provider-hardening.patch
+git -C "$plugin_dir" apply /tmp/hermes-provider-hardening.patch
+~~~
+
+### 3. Прогнать тесты до реального Opus
+
+~~~bash
+cd "$plugin_dir"
+python3 -m unittest discover -s tests -v
+~~~
+
+На чистой базе с patch у меня прошли 58 тестов. Fake-Claude тесты не расходуют подписочный лимит.
+
+### 4. Настроить loopback shim
+
+Добавьте в ~/.hermes/.env:
+
+~~~dotenv
+CLAUDE_CODE_CLI_API_KEY=local
+CLAUDE_CODE_CLI_BASE_URL=http://127.0.0.1:8765/v1
+CLAUDE_CODE_CLI_AUTOSTART=0
+~~~
+
+Значение local — непустой placeholder для registry Hermes. Shim его игнорирует.
+
+Установите managed service из provider:
+
+~~~bash
+cd "$plugin_dir"
+CLAUDE_CODE_CLI_HOST=127.0.0.1 \
+CLAUDE_CODE_CLI_PORT=8765 \
+scripts/install-service.sh
+~~~
+
+Разрешите user service работать после logout и reboot:
+
+~~~bash
+sudo loginctl enable-linger "$(id -un)"
+loginctl show-user "$(id -un)" -p Linger
+~~~
+
+Ожидаемый результат — Linger=yes.
+
+Дополните ~/.hermes/claude-code-cli-shim.env:
+
+~~~dotenv
+CLAUDE_CODE_CLI_BIN=/home/student/.local/bin/claude
+CLAUDE_CODE_CLI_MODEL=opus
+CLAUDE_CODE_CLI_ENGINE=auto
+CLAUDE_CODE_CLI_NATIVE_TOOLS=1
+CLAUDE_CODE_CLI_STREAM=1
+CLAUDE_CODE_CLI_VISION=1
+CLAUDE_CODE_CLI_STRICT_MODEL=1
+CLAUDE_CODE_CLI_TIMEOUT=600
+~~~
+
+Путь к claude замените на результат command -v claude.
+
+~~~bash
+chmod 600 ~/.hermes/.env ~/.hermes/claude-code-cli-shim.env
+systemctl --user restart claude-code-cli-shim.service
+curl -fsS http://127.0.0.1:8765/healthz
+curl -fsS http://127.0.0.1:8765/v1/models
+~~~
+
+Закройте SSH, подключитесь снова и повторите health check. Это проверяет работу user service после logout.
+
+### 5. Выбрать provider в Hermes
+
+Через picker:
+
+~~~bash
+hermes model
+~~~
+
+Выберите claude-code-cli и модель opus. В конфигурации итог должен соответствовать:
+
+~~~yaml
+model:
+  provider: claude-code-cli
+  default: opus
+~~~
+
+Теперь проверьте регистрацию provider в Hermes v0.14:
+
+~~~bash
+hermes chat -Q --provider claude-code-cli -m opus -q "Reply PROVIDER_OK"
+~~~
+
+Этот вызов уже расходует Claude usage.
+
+### 6. Доказать подписочный маршрут
+
+Перед production включением выполните один прямой probe с удалёнными metered и cloud-routing переменными:
+
+~~~bash
+env -u ANTHROPIC_API_KEY \
+    -u ANTHROPIC_AUTH_TOKEN \
+    -u ANTHROPIC_BASE_URL \
+    -u CLAUDE_CODE_USE_BEDROCK \
+    -u CLAUDE_CODE_USE_VERTEX \
+    -u CLAUDE_CODE_USE_FOUNDRY \
+  claude -p --model opus \
+    --output-format stream-json --verbose \
+    "Reply exactly SUBSCRIPTION_OPUS_OK"
+~~~
+
+Проверьте apiKeySource, served model и rate-limit event. Остановитесь при isUsingOverage=true, credits required или неожиданном API provider.
+
+После этого прогоните Hermes:
+
+~~~bash
+hermes chat -Q --provider claude-code-cli -m opus \
+  -q "Reply exactly HERMES_OPUS_OK"
+~~~
+
+Отдельно проверьте нативный Hermes tool call и memory roundtrip. Текстовый smoke доказывает только генерацию ответа.
+
+## Переключение Telegram
+
+Перед стартом Hermes остановите gateway, который сейчас использует bot token. Убедитесь, что poller исчез.
+
+Запустите Hermes gateway и проверьте три отдельные ситуации:
+
+1. обычный DM;
+2. сообщение внутри Telegram topic;
+3. тот же topic после рестарта gateway.
+
+В topic ответ должен ссылаться на входящее сообщение и сохранять topic root. Через Telegram-клиент это видно по reply_to_msg_id, reply_to_top_id и forum_topic=true.
+
+На Hermes v0.14 отдельный Telegram patch мне не понадобился. Живой ответ прошёл внутри topic до и после рестарта.
+
+Финальное состояние моего сервера:
+
+- hermes-gateway.service active/running;
+- claude-code-cli-shim.service active/running;
+- оба сервиса с NRestarts=0;
+- прежний Claude Telegram gateway inactive/dead;
+- один Telegram poller;
+- agent log: provider claude-code-cli, model opus.
 
 ## Промпт для серверного агента
 
-Всю миграцию я отдал агенту. Вот исправленная версия промпта, которая учитывает реальную архитектуру и баг Telegram topics:
-
 {{< callout insight >}}
-Переведи существующего Hermes Telegram-бота на мою подписку Anthropic через официальный Claude Code Telegram Channel.
+Подключи существующий Telegram runtime Hermes к моей подписке Anthropic через официальный Claude Code CLI и user provider.
 
-Это миграция gateway. Не меняй провайдера внутри Hermes. Сначала сделай резервную копию текущего контейнера, конфигов Hermes и Telegram gateway. Зафиксируй точный rollback.
+Сохрани Hermes gateway, sessions, memory и native tool loop. Используй pinned community provider base 09a3aec и только два commit из PR #12: 8e5c74c2 и 62420fb0.
 
-Проверь официальную установку и авторизацию Claude Code. Установи Bun и `telegram@claude-plugins-official`. Создай отдельный workspace для Claude Code. Перенеси туда только нужные инструкции и рабочие репозитории. Нужные скиллы установи в каталог Claude Code отдельно. Не заявляй перенос памяти Hermes без отдельной проверки.
+До production сверь SHA-256 versioned hardening patch со страницы и примени его.
 
-Возьми существующий Telegram bot token из защищённого конфига. Не печатай его. Создай `access.json` с mode `0600`: owner-only DM allowlist, а для нужной группы укажи её ID, `groups.<id>.allowFrom` с ID владельца и `requireMention`. Перед запуском нового gateway останови старый poller: один токен должен обслуживать ровно один процесс.
+Проверь child-env allowlist, host prompt-token accounting и Hermes v0.14 compatibility. Прогони все unit и fake-Claude tests.
 
-Проверь исходник и точную версию установленного Telegram-плагина. Если он не передаёт `message_thread_id`, сохрани backup `server.ts` и versioned patch. Сначала выполни `patch --dry-run`, затем примени hotfix в cache установленной версии: добавь ID topic во входящий channel meta, схему инструмента `reply`, `sendMessage`, отправку файлов и typing action. В инструкциях Claude Code потребуй возвращать тот же `message_thread_id` в каждом ответе внутри topic. `reply_to` оставь для quote reply. После update плагина снова проверь и при необходимости повторно примени patch.
+Создай backup и точный rollback. Установи официальный Claude Code CLI. Авторизацию выполни через мой Claude plan.
 
-Сначала запусти Claude Code интерактивно в целевом workspace и сохрани UUID проверенной сессии. Затем создай постоянный user service с явными HOME, PATH и рабочим каталогом. В `ExecStart` зафиксируй `--resume <UUID> --model opus --channels plugin:telegram@claude-plugins-official`. Для Claude Code выдели псевдо-TTY через `/usr/bin/script -qefc`, включи linger и `systemctl --user enable --now`. Закрой SSH и только после этого повтори smoke.
+Не печатай credentials и не добавляй Anthropic API key.
 
-Проверь отдельными nonce: личное сообщение, private topic, ответ после рестарта сервиса. Для topic сравни входящий и исходящий `message_thread_id`, затем проверь через Telegram-клиент, что ответ имеет тот же forum topic. Покажи статусы без токенов и приватных ID.
+Докажи через stream-json: apiKeySource=none, served Opus, subscription rate window и isUsingOverage=false. Остановись при overage, credits required или неизвестном provider.
 
-При ошибке сначала останови Claude gateway, затем верни прежний Hermes gateway. Никогда не запускай оба poller одновременно.
+Подними shim только на 127.0.0.1, managed user service, ENGINE=auto, Hermes native tools, streaming, strict model provenance и timeout 600. Включи linger и проверь сервис после logout.
+
+Проверь Hermes CLI, native tool loop и memory add/remove. Перед Telegram cutover останови текущий poller. Никогда не запускай два poller с одним token.
+
+Проверь отдельными nonce DM, forum topic и forum topic после рестарта. Через Telegram-клиент подтверди source reply, тот же topic root и forum_topic=true.
+
+Покажи финальные service states, NRestarts, единственный poller, provider/model из Hermes agent log и rollback. Продолжай исправлять, пока все проверки не пройдут.
 {{< /callout >}}
 
-Авторизацию Anthropic лучше пройти самому. Агенту достаточно увидеть статус успешного входа. Пароль, OAuth-код и содержимое файла с credentials ему отправлять не нужно.
+## Rollback
 
-## Почему бот ставил реакцию и молчал
+Сначала остановите Hermes gateway и shim. Пока оба Telegram poller остановлены, восстановите прежний provider и конфиг Hermes.
 
-После первой миграции личка отвечала. В новом private topic бот ставил реакцию 👀 и замолкал. В логах всё выглядело успешно: входящее сообщение дошло, Claude вызвал `reply`, Telegram вернул `sent`.
+Claude OAuth refresh credentials ротируются. Если rollback runtime тоже использует Claude Code, сначала передайте ему текущую credential branch и поставьте mode 0600.
 
-Причина оказалась в официальном плагине версии `0.0.6`. Во входящем событии были `chat_id` и `message_id`, инструмент `reply` принимал `reply_to`, а `message_thread_id` отсутствовал в обоих направлениях. Реакция работала, потому что она ставится на существующее сообщение. Новый ответ уходил за пределы открытого topic.
+После этого запускайте rollback gateway и повторяйте свежие DM/topic smoke. Одновременный запуск двух gateway с одним token создаёт гонку getUpdates.
 
-`reply_to` и `message_thread_id` решают разные задачи. Первый создаёт quote reply. Второй выбирает topic для нового сообщения. Общий пробел описан в [issue #1158](https://github.com/anthropics/claude-plugins-official/issues/1158).
+## Ограничения
 
-Отдельное наблюдение по private topics есть в [issue #4349](https://github.com/anthropics/claude-plugins-official/issues/4349).
+Provider поддерживается сообществом. После обновления Hermes, Claude CLI или plugin повторяйте unit, billing, tool, memory, DM, topic и restart проверки.
 
-Поле для topic определено в [Telegram Bot API](https://core.telegram.org/bots/api#sendmessage).
+Каждый turn создаёт процесс claude -p. Это добавляет latency и внутренний prompt floor Claude Code.
 
-Я добавил локальный hotfix и повторил E2E дважды. Во втором прогоне сервис был предварительно перезапущен. В обоих случаях входящий event и вызов `reply` содержали одинаковый `message_thread_id`, а Telegram-клиент подтвердил ответ внутри исходного topic.
+Anthropic документирует Claude Code и Agent SDK с подписочным планом. Постоянный owner-only Telegram transport через сторонний Hermes provider остаётся policy gray area.
 
-## Как проверить результат
+Публичного одобрения конкретной связки Hermes + Telegram от Anthropic я не нашёл.
 
-Я считаю миграцию рабочей после шести проверок:
-
-1. Claude Code видит активную подписочную авторизацию.
-2. Запущен один Telegram poller.
-3. Личное сообщение получает точный ответ.
-4. Topic-сообщение и ответ имеют одинаковый `message_thread_id`.
-5. После рестарта сервиса topic-тест проходит ещё раз.
-6. Claude читает перенесённые инструкции и видит каждый заявленный скилл.
-
-Проверка номер шесть особенно важна. Работающий Telegram ещё не означает, что память и возможности Hermes приехали вместе с токеном. Каждый артефакт нужно проверять отдельно.
-
-## Что получилось
-
-Снаружи это прежний Hermes-бот. Внутри сообщения теперь обслуживает Claude Code на подписке Anthropic. Hermes gateway остановлен и хранится как rollback.
-
-Opus отвечает в личке и проверенном private topic. После рестарта связь сохраняется. Для topics пока нужен локальный hotfix поверх официального плагина `0.0.6`; после обновления плагина его придётся проверить заново.
+Не делитесь consumer credentials и не превращайте личную подписку в multi-user backend.
 
 Похожие серверные связки и агентские отделы я собираю в Personal Corp. [Посмотреть, как это устроено](https://t.me/hashslash_bot?start=pc_blog).
 
 ---
 
-## Частые вопросы
+## Ссылки
 
-### Можно оставить Hermes runtime активным?
-
-Для одного Telegram token нужен один poller. Во время работы Claude Channel процесс Hermes gateway должен быть остановлен. Его конфиг можно сохранить для rollback.
-
-### Нужен Anthropic API key?
-
-Для этой схемы ключ не нужен. Модель запускается внутри авторизованной сессии Claude Code и использует лимит подписки.
-
-### Переносится память Hermes?
-
-Автоматически нет. Можно перенести совместимые инструкции, файлы и скиллы. Историю сессий и внутреннюю память нужно экспортировать и адаптировать отдельно.
-
-### Hotfix для topics останется навсегда?
-
-Локальный patch может исчезнуть после обновления плагина. После каждого обновления стоит проверить исходник и повторить private-topic E2E. Если Anthropic добавит `message_thread_id` upstream, локальный patch станет не нужен.
-
-### Что почитать дальше
-
-- [Как поднять AI-агента на VPS](/blog/openclaw-vps-6-dollars/)
-
-- [Как синхронизировать Claude Code между компьютерами](/blog/sync-claude-code-four-machines/)
-
-- [Как передавать агенту знания через скиллы](/blog/skills-knowledge-transfer/)
+- [Hermes: model providers](https://hermes-agent.nousresearch.com/docs/integrations/providers)
+- [Hermes Claude Code CLI provider](https://github.com/Ouroborosrex/hermes-claude-code-cli-provider)
+- [Provider issue #13: context accounting](https://github.com/Ouroborosrex/hermes-claude-code-cli-provider/issues/13)
+- [Provider PR #12: error handling and model provenance](https://github.com/Ouroborosrex/hermes-claude-code-cli-provider/pull/12)
+- [Мой проверенный hardening patch](/downloads/hermes-claude-code-cli-provider-hardening.patch)
+- [Claude Code: authentication](https://code.claude.com/docs/en/iam)
+- [Claude Code: headless mode](https://code.claude.com/docs/en/headless)
+- [Claude Agent SDK with a Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)
+- [Claude Code with Pro or Max](https://support.claude.com/en/articles/11145838-use-claude-code-with-your-pro-or-max-plan)
+- [Claude Code legal and compliance](https://code.claude.com/docs/en/legal-and-compliance)
+- [Telegram Bot API](https://core.telegram.org/bots/api)

--- a/static/downloads/hermes-claude-code-cli-provider-hardening.patch
+++ b/static/downloads/hermes-claude-code-cli-provider-hardening.patch
@@ -1,0 +1,297 @@
+diff --git a/__init__.py b/__init__.py
+index 38b110e..f05fadc 100644
+--- a/__init__.py
++++ b/__init__.py
+@@ -34,7 +34,7 @@ from providers.base import ProviderProfile
+ # Override at runtime with the CLAUDE_CODE_CLI_BASE_URL env var.
+ _DEFAULT_SHIM_BASE_URL = "http://127.0.0.1:8765/v1"
+
+-claude_code_cli = ProviderProfile(
++_profile_kwargs = dict(
+     name="claude-code-cli",
+     # Aliases deliberately avoid "claude-code" - that one belongs to the native
+     # `anthropic` profile. These point only at this local-CLI provider.
+@@ -51,13 +51,20 @@ claude_code_cli = ProviderProfile(
+     env_vars=("CLAUDE_CODE_CLI_API_KEY", "CLAUDE_CODE_CLI_BASE_URL"),
+     base_url=_DEFAULT_SHIM_BASE_URL,
+     auth_type="api_key",
+-    supports_vision=True,
+     # Model ids the shim accepts and forwards verbatim to `claude --model`.
+     # Shown in pickers when the live /models probe is unavailable.
+     fallback_models=("opus", "sonnet", "haiku"),
+     default_aux_model="haiku",
+ )
+
++# Hermes v0.14 predates the declarative ``supports_vision`` profile field.
++# Keep one plugin tree compatible with that production version and newer
++# releases while the local shim continues to accept OpenAI image parts.
++if "supports_vision" in getattr(ProviderProfile, "__dataclass_fields__", {}):
++    _profile_kwargs["supports_vision"] = True
++
++claude_code_cli = ProviderProfile(**_profile_kwargs)
++
+ register_provider(claude_code_cli)
+
+
+diff --git a/claude_code_server.py b/claude_code_server.py
+index 795d4bc..29606cc 100755
+--- a/claude_code_server.py
++++ b/claude_code_server.py
+@@ -83,13 +83,28 @@ def _env(name: str, default: str = "") -> str:
+
+
+ def build_subprocess_env() -> dict[str, str]:
+-    """Return an env with user-local CLI paths restored.
++    """Return a minimal env with user-local CLI paths restored.
+
+     Mirrors fusion_runner.build_subprocess_env: cron/gateway-launched parents
+     can have a minimal PATH that lacks ~/.local/npm/bin and nvm's node, which
+     breaks `claude`'s `/usr/bin/env node` shebang even when the binary resolves.
++    The shim may run under Hermes, whose process environment contains provider
++    and channel secrets. Pass only the OS/session values Claude Code needs plus
++    its explicit subscription credential knobs.
+     """
+-    env = os.environ.copy()
++    allowed = {
++        "HOME", "USER", "LOGNAME", "LANG", "LANGUAGE", "LC_ALL", "TERM",
++        "COLORTERM", "TMPDIR", "TMP", "TEMP", "XDG_CONFIG_HOME",
++        "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_RUNTIME_DIR",
++        "SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS",
++        "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR",
++        "DISABLE_TELEMETRY", "DISABLE_ERROR_REPORTING", "DISABLE_AUTOUPDATER",
++    }
++    env = {
++        key: value
++        for key, value in os.environ.items()
++        if key in allowed or key.startswith("LC_")
++    }
+     home = pathlib.Path.home()
+     candidates: list[pathlib.Path] = [home / ".local/npm/bin", home / ".local/bin"]
+
+@@ -744,13 +759,13 @@ def run_claude(prompt: str, model: str, engine: bool = False, overrides: dict |
+     if parsed is not None:
+         if parsed.get("is_error"):
+             msg = str(parsed.get("result") or parsed.get("error") or "claude reported is_error")
+-            return {"text": f"[claude-code-cli error] {msg}", "usage": _map_usage(parsed.get("usage")), "error": msg}
++            return {"text": f"[claude-code-cli error] {msg}", "usage": _map_usage(parsed.get("usage"), prompt), "error": msg}
+         served = _extract_served_model(parsed, model)
+         substitution = check_model_provenance(model, served)
+         if substitution:
+             return {
+                 "text": f"[claude-code-cli error] {substitution}",
+-                "usage": _map_usage(parsed.get("usage")),
++                "usage": _map_usage(parsed.get("usage"), prompt),
+                 "error": substitution,
+                 "model": served,
+             }
+@@ -760,7 +775,7 @@ def run_claude(prompt: str, model: str, engine: bool = False, overrides: dict |
+         if isinstance(result, str) and result.strip():
+             return {
+                 "text": result.strip(),
+-                "usage": _map_usage(parsed.get("usage")),
++                "usage": _map_usage(parsed.get("usage"), prompt),
+                 "error": "",
+                 "model": served,
+             }
+@@ -867,17 +882,21 @@ def _zero_usage() -> dict:
+     return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+-def _map_usage(usage) -> dict:
+-    if not isinstance(usage, dict):
+-        return _zero_usage()
+-    prompt = (
+-        int(usage.get("input_tokens", 0) or 0)
+-        + int(usage.get("cache_read_input_tokens", 0) or 0)
+-        + int(usage.get("cache_creation_input_tokens", 0) or 0)
+-    )
+-    completion = int(usage.get("output_tokens", 0) or 0)
+-    return {"prompt_tokens": prompt, "completion_tokens": completion,
+-            "total_tokens": prompt + completion}
++def _estimate_prompt_tokens(prompt: str) -> int:
++    """Estimate the OpenAI request size for Hermes context accounting.
++
++    Claude Code usage includes its own large system prompt and cache traffic,
++    which are outside the host request and can make Hermes compact too early.
++    A stable chars/4 estimate is preferable to reporting that internal usage.
++    """
++    return (len(prompt) + 3) // 4 if prompt else 0
++
++
++def _map_usage(usage, prompt: str = "") -> dict:
++    prompt_tokens = _estimate_prompt_tokens(prompt)
++    completion = int(usage.get("output_tokens", 0) or 0) if isinstance(usage, dict) else 0
++    return {"prompt_tokens": prompt_tokens, "completion_tokens": completion,
++            "total_tokens": prompt_tokens + completion}
+
+
+ # --------------------------------------------------------------------------- #
+@@ -962,7 +981,7 @@ def _extract_assistant_message_text(event: dict) -> str:
+     return ""
+
+
+-def _extract_result_event(event: dict):
++def _extract_result_event(event: dict, prompt: str = ""):
+     """Return ``(text, usage, error)`` for a terminal event, else ``None``.
+
+     Recognizes the stream-json ``{"type":"result",...}`` event *and*, defensively,
+@@ -976,10 +995,10 @@ def _extract_result_event(event: dict):
+         return None
+     if event.get("is_error"):
+         msg = str(event.get("result") or event.get("error") or "claude reported is_error")
+-        return ("", _map_usage(event.get("usage")), msg)
++        return ("", _map_usage(event.get("usage"), prompt), msg)
+     text = event.get("result")
+     text = text if isinstance(text, str) else str(event.get("content") or "")
+-    return (text, _map_usage(event.get("usage")), "")
++    return (text, _map_usage(event.get("usage"), prompt), "")
+
+
+ def _kill_proc(proc) -> None:
+@@ -1098,7 +1117,7 @@ def stream_claude(prompt: str, model: str, engine: bool = False,
+                     yield ("delta", assistant_text)
+             else:
+                 served_model = _extract_served_model(event, model) or served_model
+-                parsed = _extract_result_event(event)
++                parsed = _extract_result_event(event, prompt)
+                 if parsed is not None:
+                     result_text, result_usage, result_error = parsed
+                     saw_result = True
+diff --git a/tests/test_claude_code_server.py b/tests/test_claude_code_server.py
+index 8aef2da..41c25cd 100644
+--- a/tests/test_claude_code_server.py
++++ b/tests/test_claude_code_server.py
+@@ -44,6 +44,54 @@ def make_fake_claude(directory: pathlib.Path, body: str) -> pathlib.Path:
+
+
+ class ClaudeCodeServerUnitTests(unittest.TestCase):
++    def test_build_subprocess_env_keeps_subscription_auth_and_drops_provider_secrets(self):
++        with temporary_env(
++            ANTHROPIC_API_KEY="metered-api-key",
++            ANTHROPIC_AUTH_TOKEN="metered-auth-token",
++            ANTHROPIC_BASE_URL="https://metered.invalid",
++            CLAUDE_CODE_USE_BEDROCK="1",
++            CLAUDE_CODE_USE_VERTEX="1",
++            CLAUDE_CODE_USE_FOUNDRY="1",
++            OPENAI_API_KEY="other-provider-secret",
++            TELEGRAM_BOT_TOKEN="telegram-secret",
++            CLAUDE_CODE_OAUTH_TOKEN="subscription-oauth",
++        ):
++            child = server.build_subprocess_env()
++
++        forbidden = {
++            "ANTHROPIC_API_KEY",
++            "ANTHROPIC_AUTH_TOKEN",
++            "ANTHROPIC_BASE_URL",
++            "CLAUDE_CODE_USE_BEDROCK",
++            "CLAUDE_CODE_USE_VERTEX",
++            "CLAUDE_CODE_USE_FOUNDRY",
++            "OPENAI_API_KEY",
++            "TELEGRAM_BOT_TOKEN",
++        }
++        leaked = sorted(forbidden.intersection(child))
++        self.assertEqual(leaked, [])
++        self.assertEqual(child["CLAUDE_CODE_OAUTH_TOKEN"], "subscription-oauth")
++        self.assertTrue(child["PATH"])
++
++    def test_map_usage_estimates_only_the_host_prompt(self):
++        usage = {
++            "input_tokens": 100,
++            "cache_read_input_tokens": 5000,
++            "cache_creation_input_tokens": 5000,
++            "output_tokens": 10,
++        }
++
++        short = server._map_usage(usage, "hello")
++        long = server._map_usage(usage, "hello" + ("x" * 4000))
++
++        self.assertEqual(short, {
++            "prompt_tokens": 2,
++            "completion_tokens": 10,
++            "total_tokens": 12,
++        })
++        self.assertEqual(long["prompt_tokens"], 1002)
++        self.assertGreater(long["prompt_tokens"], short["prompt_tokens"])
++
+     def test_flatten_messages_preserves_system_conversation_and_tool_context(self):
+         prompt = server.flatten_messages([
+             {"role": "system", "content": "System rule."},
+@@ -134,7 +182,7 @@ print(json.dumps({
+                 outcome = server.run_claude("hello world", "haiku", engine=False)
+
+         self.assertEqual(outcome["text"], "fake response to world")
+-        self.assertEqual(outcome["usage"], {"prompt_tokens": 10, "completion_tokens": 7, "total_tokens": 17})
++        self.assertEqual(outcome["usage"], {"prompt_tokens": 3, "completion_tokens": 7, "total_tokens": 10})
+         self.assertEqual(outcome["error"], "")
+
+     def test_run_claude_surfaces_nonzero_exit_without_crashing(self):
+@@ -179,7 +227,14 @@ print(json.dumps({"result": "hello from fake http", "usage": {"input_tokens": 1,
+                     completion = json.loads(request.urlopen(req, timeout=5).read().decode("utf-8"))
+                     self.assertEqual(completion["object"], "chat.completion")
+                     self.assertEqual(completion["choices"][0]["message"]["content"], "hello from fake http")
+-                    self.assertEqual(completion["usage"]["total_tokens"], 3)
++                    expected_prompt = server._estimate_prompt_tokens(server.flatten_messages([
++                        {"role": "user", "content": "say hi"},
++                    ]))
++                    self.assertEqual(completion["usage"], {
++                        "prompt_tokens": expected_prompt,
++                        "completion_tokens": 2,
++                        "total_tokens": expected_prompt + 2,
++                    })
+
+                     stream_req = request.Request(
+                         base + "/v1/chat/completions",
+@@ -300,7 +355,13 @@ print(json.dumps({
+         self.assertEqual(calls[0]["type"], "function")
+         self.assertEqual(calls[0]["function"]["name"], "skill_view")
+         self.assertEqual(json.loads(calls[0]["function"]["arguments"]), {"name": "hermes-agent"})
+-        self.assertEqual(completion["usage"]["total_tokens"], 9)
++        self.assertEqual(completion["usage"]["completion_tokens"], 5)
++        self.assertGreater(completion["usage"]["prompt_tokens"], 0)
++        self.assertLess(completion["usage"]["prompt_tokens"], 1000)
++        self.assertEqual(
++            completion["usage"]["total_tokens"],
++            completion["usage"]["prompt_tokens"] + 5,
++        )
+
+     def test_native_tool_call_fallbacks_to_text_on_non_json_result(self):
+         with tempfile.TemporaryDirectory() as td:
+@@ -776,7 +837,7 @@ emit({"type": "result", "result": "hello", "usage": {"input_tokens": 4, "output_
+         self.assertEqual(len(finals), 1)
+         final = finals[0]
+         self.assertEqual(final["text"], "hello")
+-        self.assertEqual(final["usage"], {"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9})
++        self.assertEqual(final["usage"], {"prompt_tokens": 2, "completion_tokens": 5, "total_tokens": 7})
+
+     def test_stream_claude_bare_json_result_falls_back_to_single_delta(self):
+         with tempfile.TemporaryDirectory() as td:
+@@ -838,7 +899,14 @@ emit({"type": "result", "result": "onetwo", "usage": {"input_tokens": 1, "output
+                     thread.join(timeout=5)
+         self.assertIn('"content": "one"', body)
+         self.assertIn('"content": "two"', body)
+-        self.assertIn('"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}', body)
++        expected_prompt = server._estimate_prompt_tokens(server.flatten_messages([
++            {"role": "user", "content": "say hi"},
++        ]))
++        self.assertIn(
++            f'"usage": {{"prompt_tokens": {expected_prompt}, "completion_tokens": 2, '
++            f'"total_tokens": {expected_prompt + 2}}}',
++            body,
++        )
+         self.assertIn("data: [DONE]", body)
+
+
+diff --git a/tests/test_provider_plugin_registration.py b/tests/test_provider_plugin_registration.py
+index f9c6165..bec256f 100644
+--- a/tests/test_provider_plugin_registration.py
++++ b/tests/test_provider_plugin_registration.py
+@@ -41,7 +41,8 @@ class ProviderPluginRegistrationTests(unittest.TestCase):
+                 self.assertEqual(profile.api_mode, "chat_completions")
+                 self.assertEqual(profile.base_url, "http://127.0.0.1:8765/v1")
+                 self.assertEqual(profile.auth_type, "api_key")
+-                self.assertTrue(profile.supports_vision)
++                if hasattr(profile, "supports_vision"):
++                    self.assertTrue(profile.supports_vision)
+                 self.assertEqual(profile.env_vars, ("CLAUDE_CODE_CLI_API_KEY", "CLAUDE_CODE_CLI_BASE_URL"))
+                 self.assertEqual(profile.fallback_models, ("opus", "sonnet", "haiku"))
+                 self.assertEqual(profile.default_aux_model, "haiku")


### PR DESCRIPTION
## Что исправлено

- Hermes остаётся Telegram runtime;
- Opus вызывается через официальный Claude Code CLI и подписочную сессию Anthropic;
- объяснена связь Hermes, user provider и CLI;
- добавлены pinned commits, downloadable hardening patch и SHA-256;
- добавлены billing, tools, memory, DM, topics, restart, linger и rollback checks;
- ссылки собраны в конце, кавычек-ёлочек нет.

## Проверка

- fresh public clone -> pin -> PR commits -> checksum -> patch -> 58 tests: pass;
- Hugo 0.154.5 build: pass;
- Vercel preview statuses: success;
- два независимых критика: pass.

Production publish произойдёт после merge через Git-connected Vercel path.