### PR TITLE
fix(homepage): вход в Personal Corp вместо снятой мёртвой ссылки hsl.sh

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -77,6 +77,7 @@
     <li><a href="https://t.me/vibecod3rs?utm_source=sereja_tech&utm_medium=link&utm_campaign=homepage" target="_blank" rel="noopener">Сообщество Вайбкодеров</a> <span class="desc">— 2000+ человек, обсуждения и взаимопомощь</span></li>
     <li><a href="https://www.youtube.com/@serejaris?utm_source=sereja_tech&utm_medium=link&utm_campaign=homepage" target="_blank" rel="noopener">YouTube</a> <span class="desc">— туториалы и стримы про вайбкодинг</span></li>
     <li><a href="https://vibecoding.phd?utm_source=sereja_tech&utm_medium=link&utm_campaign=homepage" target="_blank" rel="noopener">Кружок Вайбкодинга</a> <span class="desc">— обучение разработке с AI</span></li>
+    <li><a href="https://pc.vibecoding.phd?utm_source=sereja_tech&utm_medium=link&utm_campaign=homepage" target="_blank" rel="noopener">Личная корпорация</a> <span class="desc">— за 8 недель собрать личную корпорацию AI-агентов</span></li>
     <li><a href="https://x.com/riiiiiiiiss?utm_source=sereja_tech&utm_medium=link&utm_campaign=homepage" target="_blank" rel="noopener">Twitter</a> <span class="desc">— генеративное искусство и код-арт</span></li>
   </ul>
 </section>


### PR DESCRIPTION
## Что сломано

На главной sereja.tech в блоке «Ссылки» стояла строка `HSL — AI-студия` с адресом
`https://hsl.sh?utm_source=sereja_tech&utm_medium=link&utm_campaign=homepage`.
Домен мёртв: `dig hsl.sh` → NXDOMAIN, `whois -h whois.nic.sh hsl.sh` → `Domain not found`.
Это не сбой DNS, а отсутствие домена в реестре `.sh`.

Причина зафиксирована в `hq/domains.md`: строка 12 — «`hsl.sh` истёк 8 апреля 2026»,
строка 68 — таблица истёкших, Namecheap предлагал реактивацию 11.04.2026 (evidence `19d7d0e8ed14a253`).
Домен не продлён пять месяцев назад.

## Что уже сделано без этого PR

Мёртвый href снят с `main` коммитом `874d449` (07.09.2026) — и на живом сайте его действительно нет:
`curl https://sereja.tech/` и `https://sereja.tech/links/` не отдают ни одного `hsl.sh`.
Жалоба человека от 06.09 опередила фикс на день.

Но снят он был **без замены**: в блоке «Ссылки» после этого не осталось ни одного входа
в Personal Corp. Канонический вход по `hq/products/personal-corp/index.md` строка 17 —
`https://pc.vibecoding.phd` → `@hashslash_bot`. PC3 стартует 22.09.2026.

## Что в этом PR

Одна строка в `layouts/index.html`: пункт «Личная корпорация» → `https://pc.vibecoding.phd`
с той же разметкой источника, что у соседей (`utm_source=sereja_tech&utm_medium=link&utm_campaign=homepage`).
Формулировка описания взята из обещания программы в `hq/products/personal-corp/index.md`.

Проверка: `hugo` собирается без ошибок; в отрендеренном `public/index.html` одно вхождение
`pc.vibecoding.phd` и ноль вхождений `hsl.sh`; `https://pc.vibecoding.phd?utm_source=sereja_tech&...` отвечает 200.

## Что решает владелец

1. **Мержить ли.** Добавление пункта в блок «Ссылки» — решение про контент главной, не про баг.
   Если вход в PC3 с личного сайта не нужен, PR можно закрыть: живой сайт и без него уже без мёртвой ссылки.
2. **Домен `hsl.sh`.** Реактивации в Namecheap больше нет: домен выпал из реестра и снова свободен.
   Вернуть его можно только обычной регистрацией `hsl.sh` заново у любого регистратора.
   Никаких правок DNS при этом в этом репозитории не требуется — сайт на Vercel, домен к нему не привязан.
3. **Ветка `feat/fable-5-1-redesign`** (редизайн, в работе параллельно) всё ещё несёт мёртвый
   `hsl.sh` в `layouts/index.html` и в снимках `docs/design-plans/2026-09-05-paper/`.
   Если её смержить как есть, мёртвая ссылка вернётся на главную. Эта ветка здесь не трогалась.
4. **Маршрут источника не доезжает до бота.** Лендинг `teach-personal-corp-landing` жёстко зашивает
   `https://t.me/hashslash_bot?start=pc_web` и `utm_*` в бота не передаёт. Значит `utm_source=sereja_tech`
   виден только в веб-аналитике, а в кассе все веб-заявки сливаются в один источник `pc_web`.
   Отдельная задача, в этом PR не чинится.

Мерж и деплой — только по слову владельца: push в `main` = деплой sereja.tech.
